### PR TITLE
Add a simple CMake build system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.24)
+project(ocijail)
+
+set(CMAKE_CXX_STANDARD 20)
+include_directories(${PROJECT_SOURCE_DIR}/)
+file(GLOB SRC_FILES ${PROJECT_SOURCE_DIR}/ocijail/*.cpp)
+add_executable(ocijail ${SRC_FILES})
+
+find_package(nlohmann_json REQUIRED)
+find_package(CLI11 REQUIRED)
+target_link_libraries(ocijail PRIVATE nlohmann_json::nlohmann_json)
+target_link_libraries(ocijail PRIVATE CLI11::CLI11)
+
+install(TARGETS ocijail)

--- a/ocijail/create.cpp
+++ b/ocijail/create.cpp
@@ -258,7 +258,7 @@ void create::run() {
         jconf.set("ip6", jail::INHERIT);
     }
     if (config.contains("hostname")) {
-        jconf.set("host.hostname", config["hostname"]);
+        jconf.set("host.hostname", to_string(config["hostname"]));
         jconf.set("host", jail::NEW);
     } else {
         jconf.set("host", jail::INHERIT);


### PR DESCRIPTION
Bazel depends on OpenJDK, which doesn't work on FreeBSD/AArch64.  This is sufficiently allow me to build on FreeBSD/AArch64.

The two dependencies are in ports, so just use find-package and rely on the ports system to install them (which lets the port rebuild automatically on security fixes in the dependencies).