### PR TITLE
create: add annotation support for the individual sysv* knobs

### DIFF
--- a/ocijail/create.cpp
+++ b/ocijail/create.cpp
@@ -224,6 +224,9 @@ void create::run() {
 
     std::unordered_map<std::string, std::optional<jail::ns>> known_ns_params = {
         {"org.freebsd.jail.vnet", std::nullopt},
+        {"org.freebsd.jail.sysvmsg", std::nullopt},
+        {"org.freebsd.jail.sysvsem", std::nullopt},
+        {"org.freebsd.jail.sysvshm", std::nullopt},
     };
     if (config.contains("annotations")) {
         auto config_annotations = config["annotations"];
@@ -310,6 +313,15 @@ void create::run() {
     jconf.set("allow.raw_sockets");
     if (allow_chflags) {
         jconf.set("allow.chflags");
+    }
+    if (known_ns_params["org.freebsd.jail.sysvmsg"]) {
+        jconf.set("sysvmsg", *known_ns_params["org.freebsd.jail.sysvmsg"]);
+    }
+    if (known_ns_params["org.freebsd.jail.sysvsem"]) {
+        jconf.set("sysvsem", *known_ns_params["org.freebsd.jail.sysvsem"]);
+    }
+    if (known_ns_params["org.freebsd.jail.sysvshm"]) {
+        jconf.set("sysvshm", *known_ns_params["org.freebsd.jail.sysvshm"]);
     }
     for (const auto& param : allow_params) {
         jconf.set(param);

--- a/ocijail/create.cpp
+++ b/ocijail/create.cpp
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <iostream>
 #include <sstream>
+#include <unordered_map>
 #include <unordered_set>
 
 #include "ocijail/create.h"
@@ -220,6 +221,10 @@ void create::run() {
     std::optional<std::string> ip4_addr;
     std::optional<std::string> ip6_addr;
     std::vector<std::string> allow_params;
+
+    std::unordered_map<std::string, std::optional<jail::ns>> known_ns_params = {
+        {"org.freebsd.jail.vnet", std::nullopt},
+    };
     if (config.contains("annotations")) {
         auto config_annotations = config["annotations"];
         if (config_annotations.contains("org.freebsd.parentJail")) {
@@ -227,17 +232,24 @@ void create::run() {
             auto pj = jail::find(*parent_jail);
             allow_chflags = pj.get<bool>("allow.chflags");
         }
-        if (config_annotations.contains("org.freebsd.jail.vnet")) {
-            std::string val = config_annotations["org.freebsd.jail.vnet"];
-            if (val == "new") {
-                vnet = jail::NEW;
-            } else if (val == "inherit") {
-                vnet = jail::INHERIT;
-            } else {
-                throw std::runtime_error(
-                    "bad value for org.freebsd.jail.vnet: " + val);
+
+        for (auto& [key, nsvalue] : known_ns_params) {
+            if (config_annotations.contains(key)) {
+                std::string val = config_annotations[key];
+                if (val == "new") {
+                    nsvalue = jail::NEW;
+                } else if (val == "inherit") {
+                    nsvalue = jail::INHERIT;
+                } else if (val == "disable") {
+                    nsvalue = jail::DISABLED;
+                } else {
+                    throw std::runtime_error(
+                        "bad value for " + key + ": " + val);
+                }
             }
         }
+
+        vnet = known_ns_params["org.freebsd.jail.vnet"].value_or(vnet);
         if (vnet == jail::INHERIT) {
             if (config_annotations.contains("org.freebsd.jail.ip4.addr")) {
                 ip4_addr = config_annotations["org.freebsd.jail.ip4.addr"];
@@ -247,6 +259,9 @@ void create::run() {
             } else if (config_annotations.contains("org.freebsd.jail.ip6.add")) {
                 ip6_addr = config_annotations["org.freebsd.jail.ip6.add"];
             }
+        } else if (vnet == jail::DISABLED) {
+            throw std::runtime_error(
+                "bad value for org.freebsd.jail.vnet: disable");
         }
 
         // Check for allow.* annotations (e.g., org.freebsd.jail.allow.mlock).

--- a/ocijail/jail.cpp
+++ b/ocijail/jail.cpp
@@ -16,15 +16,15 @@ void jail::config::set(const std::string& key, const value& val) {
     // Validate parameter types
     if (key == "jid" || key == "devfs_ruleset" || key == "enforce_statfs") {
         assert(std::holds_alternative<uint32_t>(val));
-    } else if (key == "ip4" || key == "ip6") {
+    } else if (key == "ip4" || key == "ip6" || key == "sysvmsg" ||
+               key == "sysvsem" || key == "sysvshm") {
         assert(std::holds_alternative<ns>(val));
     } else if (key == "ip4.addr" || key == "ip6.addr") {
         assert(std::holds_alternative<std::vector<uint8_t>>(val));
     } else if (key == "host" || key == "vnet") {
         assert(std::holds_alternative<ns>(val) &&
                std::get<ns>(val) != DISABLED);
-    } else if (key == "persist" || key == "sysvmsg" || key == "sysvsem" ||
-               key == "sysvshm" || key.starts_with("allow.")) {
+    } else if (key == "persist" || key.starts_with("allow.")) {
         assert(std::holds_alternative<std::monostate>(val));
     } else {
         assert(std::holds_alternative<std::string>(val));

--- a/test/create_test.py
+++ b/test/create_test.py
@@ -366,6 +366,19 @@ class test_create(unittest.TestCase):
         c["annotations"] = {"org.freebsd.jail.vnet": "inherit"}
         self.check_good_config(c)
 
+        for param in ["sysvmsg", "sysvsem", "sysvshm"]:
+            name = "org.freebsd.jail." + param
+            c["annotations"] = {name: "no"}
+            self.check_bad_config(c)
+
+            # Positive tests for the others
+            c["annotations"] = {name: "disable"}
+            self.check_good_config(c)
+            c["annotations"] = {name: "new"}
+            self.check_good_config(c)
+            c["annotations"] = {name: "inherit"}
+            self.check_good_config(c)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/create_test.py
+++ b/test/create_test.py
@@ -350,6 +350,22 @@ class test_create(unittest.TestCase):
         }
         self.check_good_config(c)
 
+    def test_ns_annotations(self):
+        c = self.config()
+
+        # Negative tests for vnet: only new/inherit accepted, reject unknown
+        # and normally valid namespace options (no and disable respctively)
+        c["annotations"] = {"org.freebsd.jail.vnet": "no"}
+        self.check_bad_config(c)
+        c["annotations"] = {"org.freebsd.jail.vnet": "disable"}
+        self.check_bad_config(c)
+
+        # Positive tests for vnet
+        c["annotations"] = {"org.freebsd.jail.vnet": "new"}
+        self.check_good_config(c)
+        c["annotations"] = {"org.freebsd.jail.vnet": "inherit"}
+        self.check_good_config(c)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is useful for better-scoping of these; using the broader allow.sysvipc param means that all three inherit the namespace from their parent, but if we only need sysvshm (for instance, postgresql) then it's much better if we can only enable it and also give it its own namespace.