### PR TITLE
Encode annotation values as json strings

### DIFF
--- a/ocijail/main.cpp
+++ b/ocijail/main.cpp
@@ -124,7 +124,7 @@ json runtime_state::report() const {
         if (!res.contains("annotations")) {
             res["annotations"] = json::object();
         }
-        res["annotations"]["org.freebsd.jail.jid"] = state_["jid"];
+        res["annotations"]["org.freebsd.jail.jid"] = std::to_string(int(state_["jid"]));
     }
     return res;
 }


### PR DESCRIPTION
This changes the new "jid" annotation in the state output from an integer to a string as requred by the runtime specificiation (https://github.com/opencontainers/runtime-spec/blob/main/config.md#annotations). Fixes #14.
