### PR TITLE
mount: improve error when volume source path does not exist

### DIFF
--- a/ocijail/mount.cpp
+++ b/ocijail/mount.cpp
@@ -437,6 +437,15 @@ retry:
             }
             std::stringstream ss;
             ss << mount;
+            if (errno == ENOENT) {
+                auto source = mount["source"].get<std::string>();
+                if (!fs::exists(source)) {
+                    throw std::runtime_error(
+                        "mounting " + ss.str() +
+                        ": source path does not exist: " + source +
+                        " (create the directory first)");
+                }
+            }
             throw std::system_error(
                 errno, std::system_category(), "mounting " + ss.str());
         }


### PR DESCRIPTION
When a nullfs mount fails with ENOENT and the source path does not exist, the current error message says:

```
No such file or directory: OCI runtime attempted to invoke a command that was not found
```

This is confusing — it sounds like a binary is missing rather than a directory. It is a common point of confusion for users mounting volumes with podman on FreeBSD.

This change checks for ENOENT + non-existent source and emits a clearer message:

```
source path does not exist: /path/to/missing (create the directory first)
```